### PR TITLE
Removes local compile definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,6 @@ target_compile_definitions(${SYSSTAT_LIBRARY_NAME}
         "MINOR_VERSION=${MINOR_VERSION}"
         "PATCH_VERSION=${PATCH_VERSION}"
         "SYSSTAT_LIBRARY"
-        "QT_NO_FOREACH"
 )
 
 target_include_directories(${SYSSTAT_LIBRARY_NAME}


### PR DESCRIPTION
QT_NO_FOREACH is already part of LXQtCompilerSettings CMake module.