### PR TITLE
Don't use automatic string conversions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,11 @@ target_compile_definitions(${SYSSTAT_LIBRARY_NAME}
         "MINOR_VERSION=${MINOR_VERSION}"
         "PATCH_VERSION=${PATCH_VERSION}"
         "SYSSTAT_LIBRARY"
+        "QT_USE_QSTRINGBUILDER"
+        "QT_NO_CAST_FROM_ASCII"
+        "QT_NO_CAST_TO_ASCII"
+        "QT_NO_URL_CAST_FROM_STRING"
+        "QT_NO_CAST_FROM_BYTEARRAY"
 )
 
 target_include_directories(${SYSSTAT_LIBRARY_NAME}

--- a/cpustat.cpp
+++ b/cpustat.cpp
@@ -49,10 +49,10 @@ void CpuStatPrivate::addSource(const QString &source)
 {
     bool ok;
 
-    uint min = readAllFile(qPrintable(QString("/sys/devices/system/cpu/%1/cpufreq/scaling_min_freq").arg(source))).toUInt(&ok);
+    uint min = readAllFile(qPrintable(QString::fromLatin1("/sys/devices/system/cpu/%1/cpufreq/scaling_min_freq").arg(source))).toUInt(&ok);
     if (ok)
     {
-        uint max = readAllFile(qPrintable(QString("/sys/devices/system/cpu/%1/cpufreq/scaling_max_freq").arg(source))).toUInt(&ok);
+        uint max = readAllFile(qPrintable(QString::fromLatin1("/sys/devices/system/cpu/%1/cpufreq/scaling_max_freq").arg(source))).toUInt(&ok);
         if (ok)
             mBounds[source] = qMakePair(min, max);
     }
@@ -62,12 +62,12 @@ void CpuStatPrivate::updateSources()
 {
     mSources.clear();
 
-    const QStringList rows = readAllFile("/proc/stat").split(QChar('\n'), QString::SkipEmptyParts);
+    const QStringList rows = readAllFile("/proc/stat").split(QLatin1Char('\n'), QString::SkipEmptyParts);
     for (const QString &row : rows)
     {
-        QStringList tokens = row.split(QChar(' '), QString::SkipEmptyParts);
+        QStringList tokens = row.split(QLatin1Char(' '), QString::SkipEmptyParts);
         if( (tokens.size() < 5)
-        || (!tokens[0].startsWith("cpu")) )
+        || (!tokens[0].startsWith(QLatin1String("cpu"))) )
             continue;
 
         mSources.append(tokens[0]);
@@ -77,10 +77,10 @@ void CpuStatPrivate::updateSources()
 
     bool ok;
 
-    const QStringList ranges = readAllFile("/sys/devices/system/cpu/online").split(QChar(','), QString::SkipEmptyParts);
+    const QStringList ranges = readAllFile("/sys/devices/system/cpu/online").split(QLatin1Char(','), QString::SkipEmptyParts);
     for (const QString &range : ranges)
     {
-        int dash = range.indexOf('-');
+        int dash = range.indexOf(QLatin1Char('-'));
         if (dash != -1)
         {
             uint min = range.leftRef(dash).toUInt(&ok);
@@ -89,14 +89,14 @@ void CpuStatPrivate::updateSources()
                 uint max = range.midRef(dash + 1).toUInt(&ok);
                 if (ok)
                     for (uint number = min; number <= max; ++number)
-                        addSource(QString("cpu%1").arg(number));
+                        addSource(QString::fromLatin1("cpu%1").arg(number));
             }
         }
         else
         {
             uint number = range.toUInt(&ok);
             if (ok)
-                addSource(QString("cpu%1").arg(number));
+                addSource(QString::fromLatin1("cpu%1").arg(number));
         }
     }
 }
@@ -118,7 +118,7 @@ void CpuStatPrivate::sourceChanged()
 void CpuStatPrivate::recalculateMinMax()
 {
     int cores = 1;
-    if (mSource == "cpu")
+    if (mSource == QLatin1String("cpu"))
         cores = mSources.size() - 1;
 
     mIntervalMin = static_cast<float>(mTimer->interval()) / 1000 * static_cast<float>(mUserHz) * static_cast<float>(cores) / 1.25; // -25%
@@ -130,15 +130,15 @@ void CpuStatPrivate::timeout()
     if ( (mMonitoring == CpuStat::LoadOnly)
       || (mMonitoring == CpuStat::LoadAndFrequency) )
     {
-        const QStringList rows = readAllFile("/proc/stat").split(QChar('\n'), QString::SkipEmptyParts);
+        const QStringList rows = readAllFile("/proc/stat").split(QLatin1Char('\n'), QString::SkipEmptyParts);
         for (const QString &row : rows)
         {
-            if (!row.startsWith("cpu"))
+            if (!row.startsWith(QLatin1String("cpu")))
                 continue;
 
-            if (row.startsWith(mSource + " "))
+            if (row.startsWith(mSource + QLatin1Char(' ')))
             {
-                QStringList tokens = row.split(QChar(' '), QString::SkipEmptyParts);
+                QStringList tokens = row.split(QLatin1Char(' '), QString::SkipEmptyParts);
                 if (tokens.size() < 5)
                     continue;
 
@@ -173,14 +173,14 @@ void CpuStatPrivate::timeout()
 
                         bool ok;
 
-                        if (mSource == "cpu")
+                        if (mSource == QLatin1String("cpu"))
                         {
                             uint count = 0;
                             freqRate = 0.0;
 
                             for (Bounds::ConstIterator I = mBounds.constBegin(); I != mBounds.constEnd(); ++I)
                             {
-                                uint thisFreq = readAllFile(qPrintable(QString("/sys/devices/system/cpu/%1/cpufreq/scaling_cur_freq").arg(I.key()))).toUInt(&ok);
+                                uint thisFreq = readAllFile(qPrintable(QString::fromLatin1("/sys/devices/system/cpu/%1/cpufreq/scaling_cur_freq").arg(I.key()))).toUInt(&ok);
 
                                 if (ok)
                                 {
@@ -199,7 +199,7 @@ void CpuStatPrivate::timeout()
                         }
                         else
                         {
-                            freq = readAllFile(qPrintable(QString("/sys/devices/system/cpu/%1/cpufreq/scaling_cur_freq").arg(mSource))).toUInt(&ok);
+                            freq = readAllFile(qPrintable(QString::fromLatin1("/sys/devices/system/cpu/%1/cpufreq/scaling_cur_freq").arg(mSource))).toUInt(&ok);
 
                             if (ok)
                             {
@@ -236,13 +236,13 @@ void CpuStatPrivate::timeout()
         bool ok;
         uint freq = 0;
 
-        if (mSource == "cpu")
+        if (mSource == QLatin1String("cpu"))
         {
             uint count = 0;
 
             for (Bounds::ConstIterator I = mBounds.constBegin(); I != mBounds.constEnd(); ++I)
             {
-                uint thisFreq = readAllFile(qPrintable(QString("/sys/devices/system/cpu/%1/cpufreq/scaling_cur_freq").arg(I.key()))).toUInt(&ok);
+                uint thisFreq = readAllFile(qPrintable(QString::fromLatin1("/sys/devices/system/cpu/%1/cpufreq/scaling_cur_freq").arg(I.key()))).toUInt(&ok);
 
                 if (ok)
                 {
@@ -257,7 +257,7 @@ void CpuStatPrivate::timeout()
         }
         else
         {
-            freq = readAllFile(qPrintable(QString("/sys/devices/system/cpu/%1/cpufreq/scaling_cur_freq").arg(mSource))).toUInt(&ok);
+            freq = readAllFile(qPrintable(QString::fromLatin1("/sys/devices/system/cpu/%1/cpufreq/scaling_cur_freq").arg(mSource))).toUInt(&ok);
         }
         emit update(freq);
     }
@@ -265,7 +265,7 @@ void CpuStatPrivate::timeout()
 
 QString CpuStatPrivate::defaultSource()
 {
-    return "cpu";
+    return QLatin1String("cpu");
 }
 
 CpuStatPrivate::Values::Values()

--- a/memstat.cpp
+++ b/memstat.cpp
@@ -37,7 +37,7 @@ MemStatPrivate::MemStatPrivate(MemStat *parent)
 
     connect(mTimer, SIGNAL(timeout()), SLOT(timeout()));
 
-    mSources << "memory" << "swap";
+    mSources << QLatin1String("memory") << QLatin1String("swap");
 }
 
 MemStatPrivate::~MemStatPrivate()
@@ -53,28 +53,28 @@ void MemStatPrivate::timeout()
     qulonglong swapTotal = 0;
     qulonglong swapFree = 0;
 
-    const QStringList rows = readAllFile("/proc/meminfo").split(QChar('\n'), QString::SkipEmptyParts);
+    const QStringList rows = readAllFile("/proc/meminfo").split(QLatin1Char('\n'), QString::SkipEmptyParts);
     for (const QString &row : rows)
     {
-        QStringList tokens = row.split(QChar(' '), QString::SkipEmptyParts);
+        QStringList tokens = row.split(QLatin1Char(' '), QString::SkipEmptyParts);
         if (tokens.size() != 3)
             continue;
 
-        if (tokens[0] == "MemTotal:")
+        if (tokens[0] == QLatin1String("MemTotal:"))
             memTotal = tokens[1].toULong();
-        else if(tokens[0] == "MemFree:")
+        else if(tokens[0] == QLatin1String("MemFree:"))
             memFree = tokens[1].toULong();
-        else if(tokens[0] == "Buffers:")
+        else if(tokens[0] == QLatin1String("Buffers:"))
             memBuffers = tokens[1].toULong();
-        else if(tokens[0] == "Cached:")
+        else if(tokens[0] == QLatin1String("Cached:"))
             memCached = tokens[1].toULong();
-        else if(tokens[0] == "SwapTotal:")
+        else if(tokens[0] == QLatin1String("SwapTotal:"))
             swapTotal = tokens[1].toULong();
-        else if(tokens[0] == "SwapFree:")
+        else if(tokens[0] == QLatin1String("SwapFree:"))
             swapFree = tokens[1].toULong();
     }
 
-    if (mSource == "memory")
+    if (mSource == QLatin1String("memory"))
     {
         if (memTotal)
         {
@@ -86,7 +86,7 @@ void MemStatPrivate::timeout()
             emit memoryUpdate(applications_d, buffers_d, cached_d);
         }
     }
-    else if (mSource == "swap")
+    else if (mSource == QLatin1String("swap"))
     {
         if (swapTotal)
         {
@@ -99,7 +99,7 @@ void MemStatPrivate::timeout()
 
 QString MemStatPrivate::defaultSource()
 {
-    return "memory";
+    return QLatin1String("memory");
 }
 
 MemStat::MemStat(QObject *parent)

--- a/netstat.cpp
+++ b/netstat.cpp
@@ -38,13 +38,13 @@ NetStatPrivate::NetStatPrivate(NetStat *parent)
     connect(mTimer, SIGNAL(timeout()), SLOT(timeout()));
 
 
-    QStringList rows(readAllFile("/proc/net/dev").split(QChar('\n'), QString::SkipEmptyParts));
+    QStringList rows(readAllFile("/proc/net/dev").split(QLatin1Char('\n'), QString::SkipEmptyParts));
 
     rows.erase(rows.begin(), rows.begin() + 2);
 
     for (const QString &row : qAsConst(rows))
     {
-        QStringList tokens = row.split(QChar(':'), QString::SkipEmptyParts);
+        QStringList tokens = row.split(QLatin1Char(':'), QString::SkipEmptyParts);
         if (tokens.size() != 2)
             continue;
 
@@ -58,31 +58,31 @@ NetStatPrivate::~NetStatPrivate()
 
 void NetStatPrivate::timeout()
 {
-    QStringList rows(readAllFile("/proc/net/dev").split(QChar('\n'), QString::SkipEmptyParts));
+    QStringList rows(readAllFile("/proc/net/dev").split(QLatin1Char('\n'), QString::SkipEmptyParts));
 
 
     if (rows.size() < 2)
         return;
 
-    QStringList names = rows[1].split(QChar('|'));
+    QStringList names = rows[1].split(QLatin1Char('|'));
     if (names.size() != 3)
         return;
-    QStringList namesR = names[1].split(QChar(' '), QString::SkipEmptyParts);
-    QStringList namesT = names[2].split(QChar(' '), QString::SkipEmptyParts);
-    int receivedIndex    =                 namesR.indexOf("bytes");
-    int transmittedIndex = namesR.size() + namesT.indexOf("bytes");
+    QStringList namesR = names[1].split(QLatin1Char(' '), QString::SkipEmptyParts);
+    QStringList namesT = names[2].split(QLatin1Char(' '), QString::SkipEmptyParts);
+    int receivedIndex    =                 namesR.indexOf(QLatin1String("bytes"));
+    int transmittedIndex = namesR.size() + namesT.indexOf(QLatin1String("bytes"));
 
     rows.erase(rows.begin(), rows.begin() + 2);
 
     for (const QString &row : qAsConst(rows))
     {
-        QStringList tokens = row.split(QChar(':'), QString::SkipEmptyParts);
+        QStringList tokens = row.split(QLatin1Char(':'), QString::SkipEmptyParts);
         if (tokens.size() != 2)
             continue;
 
         QString interfaceName = tokens[0].trimmed();
 
-        QStringList data = tokens[1].split(QChar(' '), QString::SkipEmptyParts);
+        QStringList data = tokens[1].split(QLatin1Char(' '), QString::SkipEmptyParts);
         if (data.size() < transmittedIndex)
             continue;
 
@@ -103,7 +103,7 @@ void NetStatPrivate::timeout()
 
 QString NetStatPrivate::defaultSource()
 {
-    return "lo";
+    return QLatin1String("lo");
 }
 
 NetStatPrivate::Values::Values()

--- a/version.cpp
+++ b/version.cpp
@@ -34,7 +34,7 @@ namespace version {
 
 QString verbose()
 {
-    return QString("%1.%2.%3").arg(MAJOR_VERSION_STR).arg(MINOR_VERSION_STR).arg(PATCH_VERSION_STR);
+    return QString::fromLatin1("%1.%2.%3").arg(QLatin1String(MAJOR_VERSION_STR)).arg(QLatin1String(MINOR_VERSION_STR)).arg(QLatin1String(PATCH_VERSION_STR));
 }
 
 int majorNumber()


### PR DESCRIPTION
* Disables automatic conversions from 8-bit strings (char *) to unicode
  QStrings.
* Disables automatic conversion from QString to 8-bit strings (char *).
* Disables automatic conversions from QByteArray to const char * or const
  void *.
* Disables automatic conversions from QString (or char *) to QUrl.
* Use QStringBuilder for more efficient string creation.

It make us aware of string and encoding conversions.